### PR TITLE
Add `URL` initializer to `Command`

### DIFF
--- a/Sources/SwiftSlash/Command.swift
+++ b/Sources/SwiftSlash/Command.swift
@@ -50,7 +50,35 @@ public struct Command {
 		self.environment = environment
 		self.workingDirectory = workingDirectory
 	}
-    
+
+
+	/// Convenience initializer to initialize with an executable's `URL`.
+	/// - Parameters:
+	///   - executableURL: The URL for the executable to run.
+	///   - arguments: An array of arguments to pass into the executable.
+	///   - environment: The environment variables that will be assigned before the process begins running.
+	///   - workingDirectory: The working directory that the process will have when it is launched.
+	public init(
+		executableURL: URL,
+		arguments: [String] = [],
+		environment: [String: String] = CurrentProcessState.getCurrentEnvironmentVariables(),
+		workingDirectory: URL = CurrentProcessState.getCurrentWorkingDirectory()
+	) {
+		let absolutePath: String
+		if #available(macOS 13, *) {
+			absolutePath = executableURL.path()
+		} else {
+			absolutePath = executableURL.path
+		}
+
+		self.init(
+			absolutePath: absolutePath,
+			arguments: arguments,
+			environment: environment,
+			workingDirectory: workingDirectory
+		)
+	}
+
 	/// Initialize with an executable name and arguments.
 	/// - This initializer does __not__ use a system shell to launch the work.
 	/// - Parameters:


### PR DESCRIPTION
It can often be nicer to work with `URL`s for representing file paths. What do you think of adding an initializer to `Command` that takes a `URL` for the executable path, rather than `String`?