### PR TITLE
Fix build errors with Swift 6.2

### DIFF
--- a/Sources/SwiftSlash/LineParser.swift
+++ b/Sources/SwiftSlash/LineParser.swift
@@ -30,9 +30,9 @@ internal struct LineParser:~Copyable {
 	/// the primary storage buffer for incoming data.
 	private var buffer:UnsafeMutablePointer<UInt8>
 	/// the current capacity of the buffer.
-	private var capacity:size_t
+	private var capacity:Int
 	/// the current number of bytes stored in the buffer.
-	private var count:size_t = 0
+	private var count:Int = 0
 
 	/// the byte pattern that the line parser will use to split incoming data into lines.
 	private let separator:[UInt8]
@@ -43,7 +43,7 @@ internal struct LineParser:~Copyable {
 	/// 	- separator: the byte‐pattern to split on (e.g. `Array("\r\n".utf8)`)
 	/// 	- initialCapacity: starting buffer size; will grow as needed
 	/// 	- output: the output method for the parser to use as it finds matches in the input stream
-	internal init(separator sepArg: [UInt8], initialCapacity initCapArg:size_t, output handlerArg: consuming Output) {
+	internal init(separator sepArg: [UInt8], initialCapacity initCapArg:Int, output handlerArg: consuming Output) {
 		separator = sepArg
 		capacity = max(initCapArg, sepArg.count)
 		buffer = UnsafeMutablePointer<UInt8>.allocate(capacity: capacity)
@@ -68,9 +68,9 @@ internal struct LineParser:~Copyable {
 	/// 	- writeHandler: closure that gets a free `UnsafeMutableBufferPointer<UInt8>` of at most `bytes` capacity, writes into it **up to** that many bytes, and returns how many bytes were written (0 ⇒ EOF).
 	/// - returns: the actual byte‐count read, so the caller can stop on `0`
 	/// - throws: whatever `writeHandler` throws
-	@discardableResult internal mutating func intake<E>(bytes: size_t, _ writeHandler: (UnsafeMutableBufferPointer<UInt8>) throws(E) -> size_t) throws(E) -> size_t where E: Swift.Error {
+	@discardableResult internal mutating func intake<E>(bytes:Int, _ writeHandler: (UnsafeMutableBufferPointer<UInt8>) throws(E) -> Int) throws(E) -> Int where E:Swift.Error {
 		// make room
-		ensureCapacity(for: bytes)
+		ensureCapacity(for:bytes)
 
 		// write directly into our buffer
 		let writePtr = buffer.advanced(by: count)
@@ -101,7 +101,7 @@ internal struct LineParser:~Copyable {
 
 	/// convenience: consume a whole `[UInt8]` at once
 	@discardableResult
-	internal mutating func intake(_ data: consuming [UInt8]) -> size_t {
+	internal mutating func intake(_ data: consuming [UInt8]) -> Int {
 		return withUnsafeMutablePointer(to: &data) { ptr in
 			intake(bytes: ptr.pointee.count) { buf in
 				_ = buf.initialize(from: ptr.pointee)
@@ -135,7 +135,7 @@ internal struct LineParser:~Copyable {
 		}
 	}
 
-	private mutating func ensureCapacity(for additional: size_t) {
+	private mutating func ensureCapacity(for additional:Int) {
 		guard capacity >= count + additional else {
 			var newCap = capacity * 2
 			while count + additional > newCap {
@@ -185,7 +185,7 @@ internal struct LineParser:~Copyable {
 			if leftover > 0 {
 				memmove(buffer, buffer.advanced(by: lineStart), leftover)
 			}
-			count = size_t(leftover)
+			count = Int(leftover)
 		}
 
 		if !lines.isEmpty {

--- a/Sources/SwiftSlash/Logistics.swift
+++ b/Sources/SwiftSlash/Logistics.swift
@@ -187,7 +187,7 @@ internal struct ProcessLogistics {
 				internal let terminationFuture:Future<Void, Never>
 				internal let separator:[UInt8]
 				internal let userDataStream:DataChannel.ChildWrite.ParentRead
-				internal let systemReadEventsFIFO:FIFO<size_t, Never>
+				internal let systemReadEventsFIFO:FIFO<Int, Never>
 				internal let rFH:Int32
 				internal let eventTrigger:EventTrigger
 				internal func launch(taskGroup:inout ThrowingTaskGroup<Void, Swift.Error>) {
@@ -222,7 +222,7 @@ internal struct ProcessLogistics {
 						}
 						do {
 							// prepare the lineparser to intake the data.
-							var writtenCount:size_t
+							var writtenCount:Int
 							repeat {
 								writtenCount = try lineParser.intake(bytes:largestReadSize) { wptr in
 									// read the data directly from the handle to the lineparser.

--- a/Sources/SwiftSlash/WriteStepper.swift
+++ b/Sources/SwiftSlash/WriteStepper.swift
@@ -30,7 +30,7 @@ internal struct WriteStepper:~Copyable {
 	private var data:[UInt8]
 	
 	/// the offset of the data that has been written to the file handle.
-	private var offset:size_t = 0
+	private var offset:Int = 0
 
 	/// an optional future that will be set as finished when the write operation is complete.
 	internal let completeFuture:Future<Void, DataChannel.ChildRead.ParentWrite.Error>?
@@ -43,7 +43,7 @@ internal struct WriteStepper:~Copyable {
 
 	/// writes more data into the specified file handle.
 	internal mutating func write(to writerFH:Int32) throws(FileHandleError) -> Action {
-		func exposeBytes(_ dat:UnsafeMutablePointer<UInt8>, count:size_t) throws(FileHandleError) -> size_t {
+		func exposeBytes(_ dat:UnsafeMutablePointer<UInt8>, count:Int) throws(FileHandleError) -> Int {
 			return try writerFH.writeFH(UnsafeBufferPointer<UInt8>(start:dat + offset, count:count - offset))
 		}
 		offset += try exposeBytes(&data, count:data.count)

--- a/Sources/SwiftSlashEventTrigger/EventTrigger.swift
+++ b/Sources/SwiftSlashEventTrigger/EventTrigger.swift
@@ -26,7 +26,7 @@ public final class EventTrigger:Sendable {
 	#endif
 
 	/// the type of registration that is being made to the event trigger for readers.
-	public typealias ReaderFIFO = FIFO<size_t, Never>
+	public typealias ReaderFIFO = FIFO<Int, Never>
 	/// the type of registration that is being made to the event trigger for writers.
 	public typealias WriterFIFO = FIFO<Void, Never>
 

--- a/Sources/SwiftSlashEventTrigger/EventTriggerRegister.swift
+++ b/Sources/SwiftSlashEventTrigger/EventTriggerRegister.swift
@@ -16,7 +16,7 @@ import SwiftSlashFuture
 internal enum Register {
 
 	/// register a parent process reader.
-	case reader(FIFO<size_t, Never>, Future<Void, Never>)
+	case reader(FIFO<Int, Never>, Future<Void, Never>)
 
 
 	/// register a parent process writer.

--- a/Sources/SwiftSlashEventTrigger/Platforms/LinuxEventTrigger.swift
+++ b/Sources/SwiftSlashEventTrigger/Platforms/LinuxEventTrigger.swift
@@ -21,7 +21,7 @@ import SwiftSlashGlobalSerialization
 
 /// the primary event trigger implementation for linux.
 /// 	- NOTE: this class is marked with `unchecked Sendable` because it has mutable storage for `activeTriggers`. As required by the Swift runtime, the access to this mutable storage is perfectly isolated and managed to only a single thread.
-internal final class LinuxEventTrigger:EventTriggerEngine {
+internal final class LinuxEventTrigger:EventTriggerEngine, @unchecked Sendable {
 	internal typealias ArgumentType = EventTriggerSetup<EventTriggerHandle>
 	internal typealias ReturnType = Void
 	internal typealias EventTriggerHandle = Int32

--- a/Sources/SwiftSlashEventTrigger/Platforms/LinuxEventTrigger.swift
+++ b/Sources/SwiftSlashEventTrigger/Platforms/LinuxEventTrigger.swift
@@ -19,6 +19,8 @@ import SwiftSlashFHHelpers
 import SwiftSlashFuture
 import SwiftSlashGlobalSerialization
 
+/// the primary event trigger implementation for linux.
+/// 	- NOTE: this class is marked with `unchecked Sendable` because it has mutable storage for `activeTriggers`. As required by the Swift runtime, the access to this mutable storage is perfectly isolated and managed to only a single thread.
 internal final class LinuxEventTrigger:EventTriggerEngine {
 	internal typealias ArgumentType = EventTriggerSetup<EventTriggerHandle>
 	internal typealias ReturnType = Void

--- a/Sources/SwiftSlashEventTrigger/Platforms/MacOSETImpl.swift
+++ b/Sources/SwiftSlashEventTrigger/Platforms/MacOSETImpl.swift
@@ -18,7 +18,10 @@ import SwiftSlashPThread
 import SwiftSlashFHHelpers
 import SwiftSlashGlobalSerialization
 
-internal final class MacOSEventTrigger:EventTriggerEngine {
+
+/// the primary event trigger implementation for MacOS.
+/// 	- NOTE: this class is marked with `unchecked Sendable` because it has mutable storage for `activeTriggers`. As required by the Swift runtime, the access to this mutable storage is perfectly isolated and managed to only a single thread. 
+internal final class MacOSEventTrigger:EventTriggerEngine, @unchecked Sendable {
 	internal typealias ArgumentType = EventTriggerSetup<EventTriggerHandle>
 	internal typealias ReturnType = Void
 	internal typealias EventTriggerHandle = Int32

--- a/Sources/SwiftSlashFHHelpers/FHHelpers.swift
+++ b/Sources/SwiftSlashFHHelpers/FHHelpers.swift
@@ -46,7 +46,7 @@ extension Int32 {
 	/// - parameter dataBuffer: the buffer to read the data into.
 	/// - parameter readSize: the size of data to read.
 	/// - returns: the number of bytes read.
-	public func readFH(into dataBuffer:UnsafeMutablePointer<UInt8>, size readSize:size_t) throws(FileHandleError) -> size_t {
+	public func readFH(into dataBuffer:UnsafeMutablePointer<UInt8>, size readSize:Int) throws(FileHandleError) -> Int {
 		infiniteLoop: repeat {
 			// read the data from the file handle.
 			let amountRead = read(self, dataBuffer, readSize)
@@ -78,15 +78,15 @@ extension Int32 {
 	/// - returns: the number of bytes written.
 	/// - throws: FileHandleError.error_wouldblock, FileHandleError.error_bad_fh, FileHandleError.error_invalid, FileHandleError.error_io, FileHandleError.error_nospace, FileHandleError.error_unknown.
 	/// - note: error conditions for EAGAIN and EINTR are handled internally.
-	public func writeFH(_ dataToWrite:UnsafeBufferPointer<UInt8>) throws(FileHandleError) -> size_t {
+	public func writeFH(_ dataToWrite:UnsafeBufferPointer<UInt8>) throws(FileHandleError) -> Int {
 		return try writeFH(from:dataToWrite.baseAddress!, size:dataToWrite.count)
 	}
 
-	public func writeFH(singleByte:consuming UInt8) throws(FileHandleError) -> size_t {
+	public func writeFH(singleByte:consuming UInt8) throws(FileHandleError) -> Int {
 		return try writeFH(from:&singleByte, size:1)
 	}
 
-	fileprivate func writeFH(from dataBuffer:UnsafePointer<UInt8>, size writeSize:size_t) throws(FileHandleError) -> size_t {
+	fileprivate func writeFH(from dataBuffer:UnsafePointer<UInt8>, size writeSize:Int) throws(FileHandleError) -> Int {
 		infiniteLoop: repeat {
 			// write the data to the file handle.
 			let amountWritten = write(self, dataBuffer, writeSize)

--- a/Sources/SwiftSlashFIFO/FIFO.swift
+++ b/Sources/SwiftSlashFIFO/FIFO.swift
@@ -40,7 +40,7 @@ public final class FIFO<Element, Failure>:@unchecked Sendable where Failure:Swif
 	/// initialize a new FIFO with a specified maximum element count.
 	/// - parameters:
 	///		- maximumElementCount: the maximum number of elements that may be held in the FIFO at any given time.
-	public init(maximumElementCount:size_t) {
+	public init(maximumElementCount:Int) {
 		// memory setup
 		let newPointer = __cswiftslash_fifo_init(true)
 

--- a/Sources/SwiftSlashPThread/Workspace.swift
+++ b/Sources/SwiftSlashPThread/Workspace.swift
@@ -10,7 +10,7 @@ copyright (c) tanner silva 2025. all rights reserved.
 */
 
 /// this is the primary protocol for implementing a work type that can safely initialize, run, and cancel from a pthread.
-public protocol PThreadWork {
+public protocol PThreadWork:Sendable {
 	/// the argument type that this work takes.
 	associatedtype ArgumentType:Sendable
 	
@@ -18,7 +18,7 @@ public protocol PThreadWork {
 	associatedtype ReturnType:Sendable
 	
 	/// the type of error that the work can throw.
-	associatedtype ThrowType:Swift.Error
+	associatedtype ThrowType:Swift.Error & Sendable
 	
 	/// creates a new instance of the work type.
 	init(_:consuming ArgumentType)

--- a/Tests/SwiftSlashInternalTests/SwiftSlash/EventTriggerTests.swift
+++ b/Tests/SwiftSlashInternalTests/SwiftSlash/EventTriggerTests.swift
@@ -26,7 +26,7 @@ extension SwiftSlashTests {
 		@Test("SwiftSlashEventTrigger :: reading lifecycle simple", .timeLimit(.minutes(1)))
 		func readingRegistration() async throws {
 			let newPipe = try PosixPipe()
-			let readingFIFO = FIFO<size_t, Never>()
+			let readingFIFO = FIFO<Int, Never>()
 			let asyncConsumer = readingFIFO.makeAsyncConsumer()
 			let et:EventTrigger = try await EventTrigger()
 			let fut = Future<Void, DataChannel.ChildWrite.ParentRead.Error>()
@@ -35,7 +35,7 @@ extension SwiftSlashTests {
 			}
 			try await et.register(reader:newPipe.reading, readingFIFO, finishFuture:fut)
 			#expect(try newPipe.writing.writeFH(singleByte:0x0) == 1)
-			var nextItem:size_t? = await asyncConsumer.next()
+			var nextItem:Int? = await asyncConsumer.next()
 			#expect(nextItem == 1, "readingFIFO should have 1 byte but instead found \(String(describing:nextItem))")
 			#expect(fut.hasResult() == false, "readingFIFO should not have a result but instead found hasResult == \(String(describing:fut.hasResult()))")
 			var myByte:UInt8 = 255

--- a/Tests/SwiftSlashInternalTests/SwiftSlash/SwiftSlashProcessTests.swift
+++ b/Tests/SwiftSlashInternalTests/SwiftSlash/SwiftSlashProcessTests.swift
@@ -182,7 +182,7 @@ extension SwiftSlashTests {
 					let inputString = "Hello from parent process\n"
 					let inputData = [UInt8](inputString.utf8)
 					try inputStream.yield(inputData)
-					var foundItems:size_t = 0
+					var foundItems:Int = 0
 					parseLoop: for await curItem in outputStream {
 						guard curItem.count < 2 else {
 							break parseLoop
@@ -211,7 +211,7 @@ extension SwiftSlashTests {
 			let result = try await newCommand.runSync()
 			#expect(result.exit == .code(42), "expected exit code to be 0, but got \(result.exit)")
 			#expect(result.stdout.count == 10, "expected 10 lines of output, but got \(result.stdout.count)")
-			var foundItems:size_t = 0
+			var foundItems:Int = 0
 			for line in result.stdout {
 				let curString = String(bytes:line, encoding:.utf8)
 				#expect(curString != nil, "expected non-nil output from command")

--- a/Tests/SwiftSlashInternalTests/__cswiftslash/__cswiftslash_fifo_tests.swift
+++ b/Tests/SwiftSlashInternalTests/__cswiftslash/__cswiftslash_fifo_tests.swift
@@ -55,7 +55,7 @@ extension __cswiftslash_tests {
 				return __cswiftslash_fifo_pass_cap(fifoPtr, capData)
 			}
 			/// sets the maximum number of elements in the FIFO
-			fileprivate func setMaxElements(_ maxElements: size_t) -> Bool {
+			fileprivate func setMaxElements(_ maxElements:Int) -> Bool {
 				return __cswiftslash_fifo_set_max_elements(fifoPtr, maxElements)
 			}
 			private func closeFIFO() -> (Bool, UnsafeMutableRawPointer?) {


### PR DESCRIPTION
Revisions to various internal symbols to satisfy the progressed requirements of Swift 6.2.