### PR TITLE
fix linux stdin-EOF deadlock: data-driven write loop

### DIFF
--- a/LINUX_STDIN_EOF_DEADLOCK.md
+++ b/LINUX_STDIN_EOF_DEADLOCK.md
@@ -1,0 +1,369 @@
+# Linux stdin-EOF deadlock in SwiftSlash's EventTrigger
+
+> **Affected versions:** 4.0.5 and 5.0.0 — both verified. The registration code is
+> unchanged across the 4.x/5.x line, so every release since the Linux event trigger
+> was introduced is presumed affected.
+> **Platform:** Linux only. macOS does not exhibit the bug.
+> **Severity:** functional deadlock — any consumer that pipes data into a child and
+> expects the child to see EOF on stdin hangs indefinitely.
+
+## Summary
+
+`ChildProcess` (and therefore `Command`/`runSync` on the parent side) cannot deliver a
+closing EOF on a child's stdin on Linux. The stdin *payload* is written, but the
+child's stdin file descriptor is never closed by the parent, so any child that blocks
+reading stdin until EOF (`cat`, `sort`, `wg pubkey`, `md5sum`, SSH keymgmt, …) waits
+forever, and `ChildProcess.run()` never returns.
+
+The failure is independent of call-site ordering: every order of `yield()`,
+`closeDataChannel()`, and `run()` deadlocks against an EOF-consuming child on Linux
+(verified, see [Reproduction](#reproduction)).
+
+The root cause is the edge-triggered (`EPOLLET`) registration of the stdin *writer*
+file descriptor together with a write-task loop whose EOF handling is only reachable
+on a subsequent event — an event that edge-triggered epoll can never deliver for a
+pipe that is (and remains) writable.
+
+## Report origin
+
+Wiremand — the Linux WireGuard management daemon — hit this while deriving a client
+public key via `wg pubkey` (which reads its 44-byte private key from stdin and blocks
+until EOF). The child hung in a live functional test; the parent sat in `sigsuspend`
+with the child `wg pubkey` process alive and no EPOLLOUT delivery in progress.
+
+## Affected public surface
+
+- `ChildProcess(cmd).stdin` — `DataChannel.ChildRead.ParentWrite`
+  (`yield(_:)`, `write(_:)`, `closeDataChannel()`)
+- `Command.runSync()` when the child must consume stdin to EOF
+- Everything built on the above (BYO consumers in v5 included)
+
+## Reproduction
+
+A child that reads **all of stdin until EOF** is the trigger. Minimal Swift snippet:
+
+```swift
+import SwiftSlash
+
+let proc = ChildProcess(Command(absolutePath: "/bin/cat", arguments: []))
+try proc.stdin.yield([UInt8]("hello\n".utf8))
+proc.stdin.closeDataChannel()
+let exit = try await proc.run()   // never returns on Linux; the fd is never closed
+```
+
+Four call-site orderings were exercised against two EOF-consuming children
+(`/bin/cat`, `/usr/bin/wg pubkey`) on Ubuntu 24.04 (kernel 6.8.0-137-generic),
+Swift 6.3.3, SwiftSlash 4.0.5:
+
+| Pattern | cat | wg pubkey |
+|---|---|---|
+| A: `yield()` + `closeDataChannel()` before `run()` | 🔴 deadlock (rc 124) | 🔴 deadlock (rc 124) |
+| B: `async let run()`; `yield()` after; no close | 🔴 deadlock | 🔴 deadlock |
+| C: `yield()` before `run()`; no close | 🔴 deadlock | 🔴 deadlock |
+| D: `async let run()`; `yield()` + `closeDataChannel()` after | 🔴 deadlock | 🔴 deadlock |
+
+All four timed out (coreutils `timeout 6`, exit 124). On macOS the same code against
+`/bin/cat` completes with exit 0 and the echoed payload.
+
+## Root cause
+
+### 1. The stdin writer fd is registered edge-triggered
+
+`Sources/SwiftSlashEventTrigger/Platforms/LinuxEventTrigger.swift:234–242`:
+
+```swift
+@SwiftSlashGlobalSerialization internal static func register(_ ev:EventTriggerHandlePrimitive, writer:Int32) throws(EventTriggerErrors) {
+	var newEvent = epoll_event()
+	newEvent.data.fd = writer
+	newEvent.events = UInt32(EPOLLOUT.rawValue) | UInt32(EPOLLERR.rawValue) | UInt32(EPOLLHUP.rawValue) | UInt32(EPOLLET.rawValue)
+	guard epoll_ctl(ev, EPOLL_CTL_ADD, writer, &newEvent) == 0 else {
+		throw EventTriggerErrors.writerRegistrationFailure(writer, __cswiftslash_get_errno())
+	}
+}
+```
+
+The reader registration (same file, line 229) is also `EPOLLET`, but reads are
+unaffected: a child writing output is a *transition* on the read end, so edge events
+fire naturally. Writes are the broken direction.
+
+### 2. Edge-triggered epoll is one-shot for an always-writable pipe
+
+`EPOLLET` delivers an event only on a **state transition**. A fresh pipe whose write
+end is empty is permanently *ready for writing*. `epoll_ctl(EPOLL_CTL_ADD)` on an
+already-ready fd reports readiness **once**, then never again while the fd stays
+writable — there is no unready→ready transition to detect.
+
+Verified directly against the kernel:
+
+```text
+EPOLLOUT|EPOLLET on empty pipe (initial readiness): events=[(4, 4)]
+EPOLLOUT|EPOLLET second poll:                          []          # one-shot, never re-fires
+EPOLLOUT (level) first poll:                           [(4, 4)]
+EPOLLOUT (level) second poll:                          [(4, 4)]     # re-fires while writable
+```
+
+### 3. The write task can only act on a signal, and the EOF path needs a second one
+
+`Sources/SwiftSlash/Logistics.swift:175–245` — the stdin write task drains the user
+data FIFO only inside an event wake:
+
+```swift
+taskGroup.addTask { [writeConsumer = writeConsumerFIFO.makeAsyncConsumerExplicit(), et = eventTrigger] in
+	defer {
+		try! et.deregister(writer:wFH)
+		try! wFH.closeFileHandle()          // ← the only place EOF is produced
+	}
+	...
+	systemEventLoopInfinite: repeat {
+		switch await writeConsumer.next(whenTaskCancelled:.noAction) {   // ← block until EPOLLOUT signal
+			case .element(_):
+				...
+				currentWriteStepper = await getNextWriteStep(iterator:userDataConsume)
+				guard currentWriteStepper != nil else { break systemEventLoopInfinite }  // .capped ⇒ done
+				...
+			case .capped(_): break systemEventLoopInfinite
+			...
+		}
+	} while true
+	...
+}
+```
+
+The sequence on Linux:
+
+1. `epoll_ctl(ADD, … EPOLLET)` → the single initial writability event fires.
+2. Write task wakes, `getNextWriteStep` pulls the one queued payload, flushes it to
+   the child. Data delivery works — this is why the shipped piped-input tests pass.
+3. Write task returns to `writeConsumer.next()` waiting for the **next** signal.
+4. No next signal ever arrives (edge-triggered one-shot, pipe stays writable — step 2).
+5. `closeDataChannel()` (`Sources/SwiftSlash/DataChannel.swift:161`) only marks the
+   user-data FIFO finished. The `.capped` branch that would `break` the loop and
+   reach the `defer` (deregister + close the child's stdin fd) is only evaluated
+   **on a subsequent wake** — which never comes. EOF is structurally unreachable.
+
+### 4. Why macOS is immune
+
+`Sources/SwiftSlashEventTrigger/Platforms/MacOSETImpl.swift:244–245` registers the
+writer with:
+
+```swift
+newEvent.flags = UInt16(EV_ADD | EV_CLEAR | EV_EOF)
+newEvent.filter = Int16(EVFILT_WRITE)
+```
+
+kqueue `EVFILT_WRITE` is level-triggered: it is reported while the fd is writable and
+re-issued after `EV_CLEAR` clears it, so the write task *does* receive the second
+signal, sees the finished FIFO, breaks, and closes the child's stdin. The same
+consumer code works on macOS end to end — which is why a macOS-run test suite never
+observes the bug.
+
+### 5. Why the shipped unit tests do not catch it
+
+`Tests/SwiftSlashInternalTests/SwiftSlash/SwiftSlashProcessTests.swift`:
+
+- `:141` — `sh -c 'IFS= read num && exit "$num"'` (exit-code-0-255 sweep)
+- `:170` — `sh -c 'IFS= read line && printf "%s\n" "$line"; exit 0'`
+
+Both children **exit after consuming a single line** — they never wait for EOF, so
+the missing EOF is irrelevant to them. Neither test calls `closeDataChannel()` in a
+way that requires EOF propagation. The full suite passes 47/47 on Linux (verified),
+which is consistent: the *data* path works; only *EOF* delivery is broken.
+
+## Proposed fixes
+
+### Option A — level-triggered writers (smallest change, recommended)
+
+Drop `EPOLLET` for the writer registration (leave it for readers):
+
+```swift
+newEvent.events = UInt32(EPOLLOUT.rawValue) | UInt32(EPOLLERR.rawValue) | UInt32(EPOLLHUP.rawValue)
+```
+
+Level-triggered `EPOLLOUT` re-fires while the pipe is writable, so the write task
+receives the second wake, hits the `.capped` branch, and reaches the
+`defer { …closeFileHandle() }`. No busy-loop: the loop terminates by breaking at the
+first `.capped` and then deregisters + closes the fd.
+
+### Option B — re-arm the writer after each consumed event
+
+Keep edge semantics for the signal *rate*, but explicitly re-arm the writer after each
+consumed event (re-`epoll_ctl(MOD)` with `EPOLLET`, or use `EPOLLONESHOT` + re-arm),
+so the post-flush wake that observes `.capped` is guaranteed. More moving parts than A.
+
+### Option C — handle EOF at the source
+
+When `closeDataChannel()` runs with no pending writes, have it make the event loop
+observable of the finish *synchronously* (e.g. wake the trigger via the cancel pipe so
+the pending `.capped` drain happens immediately, rather than waiting for a pipe event
+that can never arrive). Preserves edge semantics but touches the channel/trigger
+boundary.
+
+Any fix must guarantee the invariant: **once the user data FIFO is finished, the
+write fd is closed even in the absence of any further fd readiness event.**
+
+## Regression test (fails on Linux today)
+
+Add to `SwiftSlashProcessTests`:
+
+```swift
+@Test("SwiftSlashProcessTests :: stdin EOF is delivered to an EOF-consuming child",
+      .timeLimit(.minutes(1)))
+func stdinEOFDelivery() async throws {
+	// child consumes all of stdin to EOF, then confirms it saw EOF.
+	let command = Command(absolutePath: "/bin/sh", arguments: ["-c", #"cat > /dev/null && echo "EOF_OK""#])
+	let process = ChildProcess(command)
+	let exit = try await process.run()
+	#expect(exit == .code(0))
+	// additionally assert stdout contains "EOF_OK"
+}
+```
+
+A child that must observe EOF to terminate (`cat > /dev/null`, `wg pubkey`, `sort`)
+is the defining case the existing tests miss. Any fix targeting the writer path must
+make this test pass on Linux.
+
+## Environment / evidence provenance
+
+- **Host:** 45.79.19.118 — Ubuntu 24.04 (`libnftables-dev 1.0.9`), x86_64, Swift 6.3.3
+  (swiftly toolchain), SwiftSlash checked out at tags `4.0.5` and `5.0.0`(`aa77ca6`).
+- `swift test` on 4.0.5: 47/47 suites pass in ~44 s, Linux.
+- Pattern matrix: parametric `ChildProcess` driver invoking the four orderings × two
+  children, wrapped in `timeout 6`; rc 124 = deadlock.
+- Kernel check: python `select.epoll()` demonstrating EPOLLET one-shot vs level
+  re-firing, against fresh `os.pipe()` fds.
+- Downstream workaround (wiremand): feed the child's stdin from a `mkstemp` file via
+  a single `sh -c "cat '<path>' | wg pubkey"` — the path is generated internally,
+  quoted, and contains no shell metacharacters, so the shelled invocation carries no
+  injection surface and key material never appears in argv. The mechanism is
+  documented in the code comment at `WireguardExecute.generateClient`.
+- Memory/notes: the EventTrigger engine, `WriteStepper`, and the write-task loop are
+  structurally identical between 4.0.5 and 5.0.0 at the affected sites; only the
+  process/channel *front-ends* changed in 5.0.0 (BYO data channels).
+
+## Status
+
+- [x] Fix applied — not Option A/B/C as originally sketched; see [Fix applied](#fix-applied-2026-09-12)
+- [x] v5 verified against the fix (66/66 tests, macOS + Linux)
+- [ ] CHANGELOG entry — `n/a`: this repository has no CHANGELOG file; release notes are published as git tags.
+
+## Fix applied (2026-09-12)
+
+The fix is **not** any of the three originally-proposed options; empirical
+investigation changed the calculus. Two probes settled the open questions:
+
+1. **kqueue `EV_CLEAR` is NOT level-triggered.** A direct kernel probe on macOS
+   shows `EVFILT_WRITE | EV_CLEAR` fires once for an initially-writable pipe and
+   does *not* re-fire while it stays writable (second poll = no event). What
+   actually happens: **each successful `write()` re-arms the filter** (a tiny
+   16-byte write produced a fresh event). macOS "just works" because every data
+   flush is itself an event that lets the loop observe the finished FIFO —
+   there is no level-triggered re-firing to copy. Option A as literally stated
+   ("match macOS") would therefore have *diverged* from macOS's real behavior
+   and, worse, level-triggered `EPOLLOUT` on a permanently-writable pipe keeps
+   `epoll_wait` returning immediately — a busy-spin on the event-trigger thread
+   whenever any write channel is idle (this repo explicitly values CPU
+   efficiency). Option A was rejected on those grounds.
+
+2. **The write task is woken by nothing but pipe signals.** `closeDataChannel()`
+   only caps the user-data FIFO; the loop evaluatees that cap only after a
+   *writability* signal, and on Linux edge-triggered epoll never delivers a
+   second one. Worse, the same mechanism silently breaks *multi-chunk*
+   streaming on Linux: after the initial event flushes chunk 1, a chunk 2
+   yielded later sits in the user FIFO forever because the task is parked on the
+   signal FIFO, not the data FIFO.
+
+### The fix (data-driven write loop)
+
+`Sources/SwiftSlash/Logistics.swift` — the stdin write task is rewritten to be
+driven by the **user data stream** instead of by pipe readiness signals:
+
+- an element means "write these bytes to the child";
+- a cap means "channel finished — close the write descriptor" (the EOF);
+- pushing data or closing the channel resumes the consumer directly, so when
+  the loop is parked on the user stream with no bytes in flight, the finish is
+  observed **without any further pipe-readiness event** — the exact situation
+  that deadlocked on Linux. when a chunk is mid-flight in a full pipe, EOF is
+  delivered only after that chunk drains (a full→space transition that
+  edge-triggered epoll reports, and that any child reading to EOF will
+  produce); closing earlier would truncate the child's input, so deferring EOF
+  until the in-flight bytes flush is the correct ordering;
+- the writability signal consumer is consulted only when a write is refused
+  because the pipe is full.
+
+Enabling changes:
+
+- `Sources/SwiftSlashFHHelpers/FHHelpers.swift` — `writeFH` now surfaces a full
+  non-blocking pipe as `FileHandleError.error_wouldblock` (previously it
+  busy-retried `EAGAIN` forever — a latent 100%-CPU spin), and maps `EPIPE` to
+  the previously-dead `FileHandleError.error_pipe` case.
+- SIGPIPE suppression — a data-driven writer can legitimately issue a write
+  near a child's exit; with the default disposition that race kills the parent
+  with SIGPIPE (verified: a Swift runtime-mode process dies, exit 141). The
+  first launch installs `signal(SIGPIPE, SIG_IGN)` once
+  (`__cswiftslash_ignore_sigpipe`), turning the race into a recoverable EPIPE
+  (also verified: with `SIG_IGN`, the write returns `-1`/`EPIPE`). This is a
+  **process-wide disposition change**, the standard approach for pipe/socket
+  I/O (no per-descriptor SIGPIPE suppression exists for pipes on either
+  platform); it is installed exactly once per process and can never be
+  uninstalled. Children are unaffected: the spawn helper already resets every
+  disposition to default via `POSIX_SPAWN_SETSIGDEF` (verified necessary —
+  POSIX preserves *ignored* dispositions across `exec`, so without it children
+  would inherit the ignore on glibc/musl/macOS).
+
+A correctness note about the old code's SIGPIPE safety: the report's original
+reasoning ("a dead pipe never delivers EPOLLOUT") is kernel-inaccurate — a
+non-full pipe whose read end is gone is still `EPOLLOUT`-ready, and read-end
+closure is an `EPOLLERR` 0→1 edge (pipes never report `EPOLLHUP` on the write
+end). The old loop happened to be SIGPIPE-safe for a different reason: on child
+death the dispatcher runs the `EPOLLERR` branch, which completes the
+termination future *without* yielding a writability signal, so the task broke
+out of its loop instead of writing again. There was nonetheless a real, narrow
+SIGPIPE race in the old code: the single initial `EPOLLOUT` event can sit
+buffered in the max-1 signal FIFO, and finish-with-buffered ordering delivers
+that stale *element* first — the old loop then wrote after the child's death.
+The suppression in this fix closes that latent crash too.
+
+### Regression tests (all pass on macOS + Linux)
+
+The originally sketched regression test was wrong as written — it never closes
+the channel, so it deadlocks on *both* platforms. The shipped tests:
+
+- `stdinEOFDelivery` — `sh -c 'cat > /dev/null && echo "EOF_OK"'`, payload +
+  `closeDataChannel()`, asserts exit 0 and `EOF_OK` on stdout.
+- `multiChunkStreamingToEOF` — `/bin/cat`, three chunks yielded 300 ms apart,
+  byte-exact round trip after `closeDataChannel()` (catches the silent
+  multi-chunk starvation on Linux).
+- `StdinStressTests` (new suite) — mid-stream child exit survival (SIGPIPE),
+  once-only SIGPIPE suppression, and full→space backpressure through a
+  136 KB payload with a slow-reading child.
+
+### Environment note
+
+- Verified on macOS (arm64e, Swift 6.x toolchain) and the original report host
+  (45.79.19.118, Ubuntu 24.04, Swift 6.3.3): 66/66 tests, both platforms.
+- `Command.runSync()` was listed as Linux-affected. Verified empirically that it
+  hangs on **macOS too**: `runSync` never writes or closes stdin, so an
+  EOF-consuming child waits forever on any platform. That is a separate,
+  platform-independent design limitation of `runSync` (no stdin channel is
+  exposed), not this bug.
+
+### Residual risks (pre-existing, acknowledged, not changed)
+
+These were surfaced by adversarial review of the fix; none are introduced by it
+and none were changed, to keep the fix scoped to the problems this document
+highlights:
+
+- **Linux dispatcher `fatalError`s.** `LinuxEventTrigger.pthreadWork()` has
+  `default: fatalError` guards for `EPOLLHUP`+writer and `EPOLLERR`+reader
+  dispatch combinations. Against current kernels these are unreachable for
+  pipe FDs (the write end reports `EPOLLOUT`/`EPOLLERR`, never `EPOLLHUP`; the
+  read end reports `EPOLLIN`/`EPOLLHUP`, never `EPOLLERR`), and the full Linux
+  suite passes, but a future kernel/FD-type change that surfaces one of those
+  combinations would crash the event-trigger thread. Out of scope here; worth
+  a follow-up hardening pass (`fatalError` → graceful no-op).
+- **`readFH` busy-retries `EAGAIN`.** The symmetric helper still has
+  `case EAGAIN: continue`, which on both platforms aliases `EWOULDBLOCK` (same
+  value), making its `error_wouldblock` throw dead code and its full-pipe
+  (read-side) spin latent. Unreachable in practice because reads are
+  availability-bounded (`FIONREAD`); left unchanged to keep this fix on the
+  write path.

--- a/Sources/SwiftSlash/Logistics.swift
+++ b/Sources/SwiftSlash/Logistics.swift
@@ -183,63 +183,93 @@ internal struct ProcessLogistics {
 							try! wFH.closeFileHandle()
 						}
 
-						// this function will retrieve the next data chunk that the user wants to write.
-						func getNextWriteStep(iterator:borrowing FIFO<([UInt8], Future<Void, DataChannel.ChildRead.ParentWrite.Error>?), Never>.AsyncConsumerExplicit) async -> WriteStepper? {
-							switch await iterator.next(whenTaskCancelled:.noAction) {
-								case .element(let (newUserDataToWrite, writeCompleteFuture)):
-									// this is a signal that the file handle is ready for writing.
-									return WriteStepper(newUserDataToWrite, writeFuture:writeCompleteFuture)
-								case .capped(_):
-									// this is a signal that the file handle is not ready for writing.
-									return nil
-								case .wouldBlock:
-									fatalError("SwiftSlashFIFO :: unexpected wouldBlock condition in WriteTask.launch()")
-							}
-						}
-
-						// this function will attempt to write the entire contents of the current write step to the file handle.
-						func flushCurrentStep(_ currentWriteStep:inout WriteStepper?) throws(FileHandleError) {
-							switch try currentWriteStep!.write(to:wFH) {
-								case .retireMe:
-									currentWriteStep = nil
-									return
-								case .holdMe:
-									return
-							}
-						}
-
+						// the write loop is driven by the user data stream rather than by
+						// pipe readiness signals. an element means "write these bytes to
+						// the child"; a cap means "the channel is finished — close the
+						// write descriptor", which is what delivers EOF to the child.
+						// pushing data or closing the channel resumes this consumer
+						// directly, so with no bytes in flight the finish is observed
+						// without any further pipe-readiness event — the exact situation
+						// that deadlocked on linux (LINUX_STDIN_EOF_DEADLOCK.md). when a
+						// step is mid-flight in a full pipe, the finish is observed once
+						// that step drains: a full->space transition, which the
+						// edge-triggered trigger always reports, and which any child
+						// that reads to EOF will produce. closing earlier would truncate
+						// the child's input, so deferring EOF until the in-flight bytes
+						// are flushed is the correct ordering. the writability consumer
+						// is consulted only while a write is refused because the pipe is
+						// full.
 						let userDataConsume = userDataStream.makeAsyncConsumer()
 
-						var currentWriteStepper:WriteStepper? = nil
-						// main loop. if this loop is broken, it means that the termination future has been set.
-						systemEventLoopInfinite: repeat {
-							// wait for the system to indicate that the file handle is ready for writing.
-							switch await writeConsumer.next(whenTaskCancelled:.noAction) {
-								case .element(_):
-									if currentWriteStepper == nil {
-										// this is a signal that the file handle is ready for writing.
-										currentWriteStepper = await getNextWriteStep(iterator:userDataConsume)
-										guard currentWriteStepper != nil else {
-											// user is ready for this stream to be closed.
-											break systemEventLoopInfinite
+						// the channel is finished — the user closed it, or the child
+						// exited (which caps the user stream too). fail every buffered
+						// write so no caller can hang on a future that will never
+						// complete, then let the defer close the write descriptor.
+						func drainPendingWrites() async {
+							finalFlushLoop: while true {
+								switch await userDataConsume.next(whenTaskCancelled:.noAction) {
+									case .element(let (_, writeCompleteFuture)):
+										_ = try? writeCompleteFuture?.setFailure(.dataChannelClosed)
+									case .capped(_):
+										break finalFlushLoop
+									case .wouldBlock:
+										fatalError("SwiftSlashFIFO :: unexpected wouldBlock condition in WriteTask.launch()")
+								}
+							}
+						}
+
+						writeLoop: while true {
+							switch await userDataConsume.next(whenTaskCancelled:.noAction) {
+								case .element(let (newUserDataToWrite, writeCompleteFuture)):
+									// flush this step in its entirety, bridging backpressure.
+									var currentWriteStepper = WriteStepper(newUserDataToWrite, writeFuture:writeCompleteFuture)
+									flushLoop: while true {
+										// resolve the outcome of a write attempt. a full
+										// pipe surfaces either as a refused write
+										// (EWOULDBLOCK on the non-blocking descriptor,
+										// mapped to .error_wouldblock) or as a partial
+										// write (.holdMe); both leave the remaining bytes
+										// to be flushed once the pipe gains space.
+										let isStepRetired:Bool
+										do {
+											switch try currentWriteStepper.write(to:wFH) {
+												case .retireMe:
+													isStepRetired = true
+												case .holdMe:
+													isStepRetired = false
+											}
+										} catch FileHandleError.error_wouldblock {
+											isStepRetired = false
+										} catch FileHandleError.error_pipe {
+											// the child's read end is gone. the in-flight
+											// step can never complete; fail it and treat
+											// the channel as closed (the defer closes the
+											// descriptor, and run() reaps the child).
+											_ = try? writeCompleteFuture?.setFailure(.dataChannelClosed)
+											await drainPendingWrites()
+											break writeLoop
+										}
+										if isStepRetired {
+											break flushLoop
+										}
+										// the pipe is full. block on the next writability
+										// signal. a cap here means the child has exited
+										// mid-flush: the in-flight step can never complete.
+										switch await writeConsumer.next(whenTaskCancelled:.noAction) {
+											case .element(_):
+												continue flushLoop
+											case .capped(_):
+												_ = try? writeCompleteFuture?.setFailure(.dataChannelClosed)
+												await drainPendingWrites()
+												break writeLoop
+											case .wouldBlock:
+												fatalError("SwiftSlashFIFO :: unexpected wouldBlock condition in WriteTask.launch()")
 										}
 									}
-									try flushCurrentStep(&currentWriteStepper)
 								case .capped(_):
-									// this is a signal that the file handle is not ready for writing.
-									break systemEventLoopInfinite
-								case .wouldBlock:
-									fatalError("SwiftSlashFIFO :: unexpected wouldBlock condition in WriteTask.launch()")
-							}
-						} while true
-						// data channel has been terminated. now we need to just cleanup any pending writes that the user might have stored in the FIFO. all futures found in the fifo at this point will be returned with an error instead of a successful completion or cancellation.
-						finalFlushLoop: while currentWriteStepper != nil {
-							switch await userDataConsume.next(whenTaskCancelled:.noAction) {
-								case .element(let (_, writeCompleteFuture)):
-									_ = try? writeCompleteFuture?.setFailure(.dataChannelClosed)
-								case .capped(_):
-									// this is a signal that the file handle is not ready for writing.
-									break finalFlushLoop
+									// the user closed the channel (or the child exited).
+									await drainPendingWrites()
+									break writeLoop
 								case .wouldBlock:
 									fatalError("SwiftSlashFIFO :: unexpected wouldBlock condition in WriteTask.launch()")
 							}
@@ -315,6 +345,10 @@ internal struct ProcessLogistics {
 	/// the event trigger that will be used to facilitate the IO exchange between the parent and child process.
 	@SwiftSlashGlobalSerialization fileprivate static var eventTrigger:EventTrigger? = nil
 
+	/// guards the once-only suppression of SIGPIPE in the parent process.
+	/// only mutated inside `launch`, which is globally serialized.
+	@SwiftSlashGlobalSerialization private static var didSuppressParentSIGPIPE = false
+
 	/// registers a process exit monitor with the event trigger. serialized because the trigger's registration stream is shared across launches.
 	@SwiftSlashGlobalSerialization internal static func registerProcessExitMonitor(_ pid:pid_t, on trigger:EventTrigger, fifo:consuming FIFO<Int, Never>) throws {
 		try trigger.register(process:pid, fifo)
@@ -338,6 +372,22 @@ internal struct ProcessLogistics {
 		// cooperative reaping of the child process.
 		if eventTrigger == nil {
 			eventTrigger = try EventTrigger()
+		}
+
+		// the parent writes to the child's stdin through a non-blocking pipe, and
+		// that write can race the child's exit. without SIGPIPE suppressed, the
+		// race terminates the parent before write() can return EPIPE. suppressing
+		// it turns the race into a normal EPIPE error, which the write loop treats
+		// as a closed channel. NOTE: this is a process-wide disposition change and
+		// is the standard approach for pipe/socket I/O (there is no per-descriptor
+		// SIGPIPE suppression for pipes on either supported platform); it is
+		// installed exactly once per process, at the first launch, and can never
+		// be uninstalled. children are unaffected: the spawn helper resets every
+		// signal disposition to default via POSIX_SPAWN_SETSIGDEF, so a child
+		// never inherits the ignored disposition.
+		if Self.didSuppressParentSIGPIPE == false {
+			Self.didSuppressParentSIGPIPE = true
+			__cswiftslash_ignore_sigpipe()
 		}
 
 		// caller-provided ("bring your own") descriptors that must be bound to child

--- a/Sources/SwiftSlashFHHelpers/FHHelpers.swift
+++ b/Sources/SwiftSlashFHHelpers/FHHelpers.swift
@@ -77,8 +77,8 @@ extension Int32 {
 	/// writes the data provided into self (represented as a system file handle).
 	/// - parameter dataToWrite: the data to write into the file handle.
 	/// - returns: the number of bytes written.
-	/// - throws: FileHandleError.error_wouldblock, FileHandleError.error_bad_fh, FileHandleError.error_invalid, FileHandleError.error_io, FileHandleError.error_nospace, FileHandleError.error_unknown.
-	/// - note: error conditions for EAGAIN and EINTR are handled internally.
+	/// - throws: FileHandleError.error_wouldblock, FileHandleError.error_bad_fh, FileHandleError.error_invalid, FileHandleError.error_io, FileHandleError.error_nospace, FileHandleError.error_pipe, FileHandleError.error_unknown.
+	/// - note: an interruption (EINTR) is handled internally and the write is retried. a non-blocking file handle whose pipe (or socket) is full surfaces as FileHandleError.error_wouldblock and blocks no thread.
 	public func writeFH(_ dataToWrite:UnsafeBufferPointer<UInt8>) throws(FileHandleError) -> Int {
 		return try writeFH(from:dataToWrite.baseAddress!, size:dataToWrite.count)
 	}
@@ -92,12 +92,14 @@ extension Int32 {
 			// write the data to the file handle.
 			let amountWritten = write(self, dataBuffer, writeSize)
 			guard amountWritten >= 0 else {
-				// need to actually think about better ways to handle these at some point.
 				let errNo = __cswiftslash_get_errno()
 				switch errNo {
-					case EAGAIN:
-						continue infiniteLoop 
 					case EWOULDBLOCK:
+						// a full pipe. on both supported platforms EAGAIN and
+						// EWOULDBLOCK share a single value (11 on linux, 35 on
+						// darwin), so this case covers the non-blocking "would
+						// block" condition of both names. the caller is expected
+						// to park on a readiness signal and retry.
 						throw FileHandleError.error_wouldblock;
 					case EBADF:
 						throw FileHandleError.error_bad_fh;
@@ -109,6 +111,12 @@ extension Int32 {
 						throw FileHandleError.error_io;
 					case ENOSPC:
 						throw FileHandleError.error_nospace;
+					case EPIPE:
+						// the pipe has no readers (its child exited or closed its
+						// end). SIGPIPE is suppressed process-wide (see
+						// __cswiftslash_ignore_sigpipe), so this surfaces as a
+						// recoverable error instead of terminating the process.
+						throw FileHandleError.error_pipe;
 					default:
 						throw FileHandleError.error_unknown(errNo);
 				}

--- a/Sources/__cswiftslash_posix_helpers/__cswiftslash_posix_helpers.c
+++ b/Sources/__cswiftslash_posix_helpers/__cswiftslash_posix_helpers.c
@@ -67,6 +67,10 @@ int __cswiftslash_fcntl_getfl(int fd) {
 	return fcntl(fd, F_GETFL);
 }
 
+void __cswiftslash_ignore_sigpipe(void) {
+	signal(SIGPIPE, SIG_IGN);
+}
+
 /// Cross-platform addchdir shim for spawn file actions.
 /// - macOS >= 10.15: posix_spawn_file_actions_addchdir_np (deprecated in 26.0,
 ///   superseded by addchdir, but _np remains available and portable to .v15)

--- a/Sources/__cswiftslash_posix_helpers/__cswiftslash_posix_helpers.h
+++ b/Sources/__cswiftslash_posix_helpers/__cswiftslash_posix_helpers.h
@@ -69,6 +69,12 @@ int __cswiftslash_fcntl_getfd(int fd);
 /// @return the file status flags on success, or -1 with errno set.
 int __cswiftslash_fcntl_getfl(int fd);
 
+/// swift cannot portably reference the SIG_IGN macro, so this function is a
+/// wrapper around signal(SIGPIPE, SIG_IGN). suppresses the terminating SIGPIPE
+/// that a write to a pipe with no readers (a child that just exited) would
+/// otherwise raise, so the write returns EPIPE and can be handled as an error.
+void __cswiftslash_ignore_sigpipe(void);
+
 /// Spawn a child process via posix_spawn with dup2 file actions and optional chdir.
 /// @param pid_out receives the child pid on success (may be NULL).
 /// @param path the executable path.

--- a/Tests/SwiftSlashInternalTests/SwiftSlash/StdinStressTests.swift
+++ b/Tests/SwiftSlashInternalTests/SwiftSlash/StdinStressTests.swift
@@ -1,0 +1,83 @@
+import Testing
+@testable import SwiftSlash
+import __cswiftslash_posix_helpers
+import SwiftSlashFHHelpers
+
+extension Tag {
+	@Tag internal static var swiftSlashStdinStress:Self
+}
+
+/// adversarial coverage for the stdin write path (LINUX_STDIN_EOF_DEADLOCK.md).
+/// the two regression tests prove EOF delivery and streamed multi-chunk writes;
+/// these prove the failure modes around them: a child that exits mid-stream
+/// (SIGPIPE must be suppressed so the parent survives), the once-only SIGPIPE
+/// suppression itself, and full-pipe backpressure where the write loop parks on
+/// the writability signal and resumes on full->space transitions.
+extension SwiftSlashTests {
+	@Suite("SwiftSlashStdinStress",
+		.serialized,
+		.tags(.swiftSlashStdinStress)
+	)
+	struct SwiftSlashStdinStress {
+
+		@Test("SwiftSlashProcessTests :: parent survives a child that exits mid-stream",
+			.timeLimit(.minutes(1))
+		)
+		func childExitsMidStream() async throws {
+			// the child reads one line and exits with 7. the parent keeps a large
+			// stream buffered behind it: some of those writes race the child's
+			// exit. the parent must survive (SIGPIPE suppressed) and run() must
+			// return the child's exit instead of crashing or hanging.
+			let command = Command(absolutePath:"/bin/sh", arguments:["-c", #"IFS= read -r _ && exit 7"#])
+			let process = ChildProcess(command)
+			async let exitResult = process.run()
+			try process.stdin.yield([UInt8]("hello\n".utf8))
+			let big = [UInt8](repeating: 65, count: 300_000)
+			try? process.stdin.yield(big)
+			try await Task.sleep(for:.milliseconds(400))
+			process.stdin.closeDataChannel()
+			let exit = try await exitResult
+			#expect(exit == .code(7), "expected the child's exit code to surface, got \(exit)")
+		}
+
+		@Test("SwiftSlashProcessTests :: SIGPIPE is suppressed once a child has been launched",
+			.timeLimit(.minutes(1))
+		)
+		func sigpipeSuppressedAfterLaunch() async throws {
+			// the first launch installs the suppression. a subsequent write to a
+			// pipe whose read end is gone must surface EPIPE (.error_pipe)
+			// instead of terminating the process with SIGPIPE.
+			let p1 = ChildProcess(Command(absolutePath:"/bin/echo"))
+			_ = try await p1.run()
+			let dead = try PosixPipe()
+			try dead.reading.closeFileHandle()
+			var threwPipe = false
+			do {
+				_ = try dead.writing.writeFH(singleByte:0x41)
+			} catch FileHandleError.error_pipe {
+				threwPipe = true
+			}
+			#expect(threwPipe, "expected the write to a readerless pipe to surface EPIPE")
+		}
+
+		@Test("SwiftSlashProcessTests :: backpressure through full->space transitions",
+			.timeLimit(.minutes(1))
+		)
+		func backpressureFullToSpace() async throws {
+			// a child that reads stdin slowly to completion. the payload is far
+			// larger than the pipe buffer, so the write loop must park on the
+			// writability signal repeatedly and resume on full->space transitions.
+			let command = Command(absolutePath:"/bin/sh", arguments:["-c", #"i=0; while IFS= read -r _x; do i=$((i+1)); [ $((i%100)) -eq 0 ] && sleep 0.002; done; exit 0"#])
+			let process = ChildProcess(command)
+			async let exitResult = process.run()
+			let line = Array("0123456789abcdef\n".utf8)
+			// well above the 64k pipe buffer, so the write loop must fill, park,
+			// and resume on full->space transitions several times.
+			let payload = (0..<8000).flatMap { _ in line }
+			try process.stdin.yield(payload)
+			process.stdin.closeDataChannel()
+			let exit = try await exitResult
+			#expect(exit == .code(0), "expected the slow-reader child to finish via backpressure, got \(exit)")
+		}
+	}
+}

--- a/Tests/SwiftSlashInternalTests/SwiftSlash/SwiftSlashProcessTests.swift
+++ b/Tests/SwiftSlashInternalTests/SwiftSlash/SwiftSlashProcessTests.swift
@@ -224,5 +224,67 @@ extension SwiftSlashTests {
 			}
 			#expect(foundItems == 10, "expected to find exactly 10 output items from child process")
 		}
+
+		@Test("SwiftSlashProcessTests :: stdin EOF is delivered to an EOF-consuming child", 
+			.timeLimit(.minutes(1))
+		)
+		func stdinEOFDelivery() async throws {
+			// the child must consume all of stdin to EOF before it can proceed. this
+			// deadlocked on linux (see LINUX_STDIN_EOF_DEADLOCK.md): the payload was
+			// written but the child's stdin descriptor was never closed, so the child
+			// waited for EOF forever and run() never returned.
+			let command = Command(absolutePath:"/bin/sh", arguments:["-c", #"cat > /dev/null && echo "EOF_OK""#])
+			let process = ChildProcess(command)
+			let outTask = Task {
+				var build = [[UInt8]]()
+				for await chunk in process.stdout {
+					build.append(contentsOf:chunk)
+				}
+				return build
+			}
+			async let exitResult = process.run()
+			// send a payload, then signal EOF by closing the channel.
+			try process.stdin.yield([UInt8]("hello\n".utf8))
+			process.stdin.closeDataChannel()
+			let exit = try await exitResult
+			#expect(exit == .code(0), "expected the child to see EOF and exit 0, got \(exit)")
+			let captured = await outTask.value
+			let joined = String(bytes:captured.flatMap{$0}, encoding:.utf8) ?? ""
+			#expect(joined.contains("EOF_OK"), "expected the child to observe EOF and print EOF_OK, got \(joined)")
+		}
+
+		@Test("SwiftSlashProcessTests :: multi-chunk piped input reaches an EOF-consuming child", 
+			.timeLimit(.minutes(1))
+		)
+		func multiChunkStreamingToEOF() async throws {
+			// chunks yielded over time (not in a single burst) must each reach the
+			// child, and the final close must deliver EOF. on linux the old
+			// signal-driven write loop never resumed after the first chunk, so
+			// everything past chunk one was lost and EOF was never delivered.
+			let command = Command(absolutePath:"/bin/cat", arguments:[])
+			let process = ChildProcess(command)
+			let outTask = Task {
+				var build = [UInt8]()
+				for await chunk in process.stdout {
+					build.append(contentsOf:chunk.flatMap{$0})
+				}
+				return build
+			}
+			async let exitResult = process.run()
+			let chunks:[[UInt8]] = [
+				[UInt8]("first-chunk-".utf8),
+				[UInt8]("second-chunk-".utf8),
+				[UInt8]("third-chunk".utf8)
+			]
+			for chunk in chunks {
+				try process.stdin.yield(chunk)
+				try await Task.sleep(for:.milliseconds(300))
+			}
+			process.stdin.closeDataChannel()
+			let exit = try await exitResult
+			#expect(exit == .code(0), "expected the child to see EOF and exit 0, got \(exit)")
+			let captured = await outTask.value
+			#expect(captured == chunks.flatMap{$0}, "expected the child to echo every yielded byte back")
+		}
 	}
 }


### PR DESCRIPTION
the stdin write task waited on a writability-signal FIFO and only pulled user data after a pipe readiness event. on linux the writer fd is registered edge-triggered (EPOLLET), which reports an always-writable pipe exactly once, so the loop never woke again: EOF was structurally unreachable (closeDataChannel only capped the user FIFO, observed only on a subsequent wake that never came), and even multi-chunk streaming starved after the first chunk. macOS worked only because each write() re-arms the kqueue filter (verified empirically: EV_CLEAR is NOT level-triggered).

rewrite the loop to be driven by the user data stream itself: an element means "write these bytes", a cap means "close the fd" (the EOF), and pushes/finish wake it directly with no further fd event required. the writability signal is consulted only when a write is refused because the pipe is full — where edge-triggered epoll does report the full->space transition.

enabling changes:
- writeFH surfaces a full non-blocking pipe as .error_wouldblock (previously busy-retried EAGAIN forever) and maps EPIPE to the previously-dead .error_pipe case.
- once-only SIGPIPE suppression at first launch (__cswiftslash_ignore_ sigpipe) so a write racing a child's exit returns EPIPE instead of killing the parent with SIGPIPE; children are untouched because the spawn helper resets every disposition via POSIX_SPAWN_SETSIGDEF.
- fix a latent dangling write future when the child exits mid-flush.

regression + stress tests covering EOF delivery to an EOF-consuming child, sustained multi-chunk streaming, mid-stream child-exit survival, once-only SIGPIPE suppression, and full->space backpressure. 66/66 tests pass on macOS and linux.